### PR TITLE
any_iterator.hpp: fix T shadows template parameter

### DIFF
--- a/any_iterator.hpp
+++ b/any_iterator.hpp
@@ -51,10 +51,10 @@ class any_iterator : std::iterator<std::bidirectional_iterator_tag, T>
     };
 
     //interface to get the number
-    template <typename T>
+    template <typename IterType>
     static size_t getNumber()
     {
-        static Incrementer i = Incrementer(T());
+        static Incrementer i = Incrementer(IterType());
         return i.number;
     }
 
@@ -149,8 +149,8 @@ public:
         return functionPtrs_[index_].equal_fn(ptr_, reinterpret_cast<const void*>(&_rhs));
     }
 
-    template <typename T>
-    bool operator!=(const T& _rhs) const{
+    template <typename IterType>
+    bool operator!=(const IterType& _rhs) const{
         return !operator==(_rhs);
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,6 @@ set(SRCS
  "basic.cpp"
  "main.cpp")
 
-add_executable(tests "../AnyIterator.hpp" ${SRCS})
+add_executable(tests "../any_iterator.hpp" ${SRCS})
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT tests) #requires cmake 3.6
 add_dependencies(tests catch)

--- a/tests/basic.cpp
+++ b/tests/basic.cpp
@@ -1,5 +1,5 @@
 #include <catch.hpp>
-#include <AnyIterator.hpp>
+#include <any_iterator.hpp>
 
 // containers
 #include <vector>


### PR DESCRIPTION
```
In file included from tests/basic.cpp:2:0:
any_iterator.hpp:54:15: error: declaration of template parameter ‘T’ shadows template parameter
     template <typename T>
               ^~~~~~~~
any_iterator.hpp:8:10: note: template parameter ‘T’ declared here
 template<typename T>
          ^~~~~~~~
any_iterator.hpp:152:15: error: declaration of template parameter ‘T’ shadows template parameter
     template <typename T>
               ^~~~~~~~
any_iterator.hpp:8:10: note: template parameter ‘T’ declared here
 template<typename T>
          ^~~~~~~~
```